### PR TITLE
Ignore http error on deletion

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -30,8 +30,8 @@ export const run = async (inputs: Inputs): Promise<void> => {
       })
       core.info(`Deleted deployment ${deployment.url}`)
     } catch (error) {
-      if (error instanceof RequestError && error.status === 422) {
-        core.warning(`unable to delete previous deployment ${deployment.url}: ${error.message}`)
+      if (error instanceof RequestError) {
+        core.warning(`unable to delete previous deployment ${deployment.url}: ${error.status} ${error.message}`)
         continue
       }
       throw error


### PR DESCRIPTION
Follow up https://github.com/int128/deployment-action/pull/8.

GitHub API eventually returns 404 error when this action deletes the old deployments.

```
Deleting previous 1 deployment(s)
Error: Not Found
```